### PR TITLE
Remove ibc pfm genesis params

### DIFF
--- a/chaosnet/genesis.json
+++ b/chaosnet/genesis.json
@@ -1932,9 +1932,6 @@
       }
     },
     "packetfowardmiddleware": {
-      "params": {
-        "fee_percentage": "0.000000000000000000"
-      },
       "in_flight_packets": {}
     },
     "pubkey": {


### PR DESCRIPTION
This is no longer used in the latest version of the PFM